### PR TITLE
Use pytest-beartype-tests plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
+    "pytest-beartype-tests",
     "pytest-cov==7.1.0",
     "ruff==0.15.11",
     # We add shellcheck-py not only for shell scripts and shell code blocks,
@@ -75,6 +76,9 @@ optional-dependencies.dev = [
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Source = "https://github.com/adamtheturtle/sphinx-combine"
+
+[dependency-groups]
+dev = []
 
 [tool.setuptools]
 zip-safe = false
@@ -95,6 +99,9 @@ bdist_wheel.universal = true
 #
 # Code to match this is in ``conf.py``.
 version_scheme = "post-release"
+
+[tool.uv]
+sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 line-length = 79
@@ -323,7 +330,6 @@ ignore_path = [
 ignore_names = [
     # pytest configuration
     "pytest_collect_file",
-    "pytest_collection_modifyitems",
     "pytest_plugins",
     # pytest fixtures - we name fixtures like this for this purpose
     "fixture_*",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,3 @@
 """Configuration for pytest."""
 
-import pytest
-from beartype import beartype
-
 pytest_plugins = "sphinx.testing.fixtures"  # pylint: disable=invalid-name
-
-
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Apply the beartype decorator to all collected test functions."""
-    for item in items:
-        # All our tests are functions, for now
-        assert isinstance(item, pytest.Function)
-        item.obj = beartype(obj=item.obj)


### PR DESCRIPTION
This PR adds the [`pytest-beartype-tests`](https://github.com/adamtheturtle/pytest-beartype-tests) dev dependency and removes redundant `pytest_collection_modifyitems` wiring from conftest where it duplicated the plugin.

The dependency is pinned to [git `bc81d99`](https://github.com/adamtheturtle/pytest-beartype-tests/commit/bc81d99) via `[tool.uv.sources]` until a PyPI release includes the Sybil-safe plugin fix.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to dev/test configuration, though pinning a git-sourced pytest plugin could affect test collection behavior in CI.
> 
> **Overview**
> **Test configuration now relies on `pytest-beartype-tests` instead of local wiring.** The manual `pytest_collection_modifyitems` hook in `tests/conftest.py` (which wrapped tests with `beartype`) is removed.
> 
> `pyproject.toml` adds `pytest-beartype-tests` to dev dependencies and pins it to git rev `bc81d99` via `tool.uv.sources`; related config cleanup drops the unused `pytest_collection_modifyitems` entry from `tool.vulture.ignore_names` and adds an empty `[dependency-groups]` section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a20ca81fa228885bdd2303a4bb9e4ba5da949aa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->