### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,7 +129,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -140,7 +140,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -140,8 +140,9 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
-          --num-workers=4"
+        entry: >-
+          uv run --extra=dev doccmd --command="mypy --num-workers=4" --no-write-to-file
+          --language=python
         language: python
         types_or: [markdown, rst]
 


### PR DESCRIPTION
## Summary
- Enable `mypy` pre-commit hook parallelization with `--num-workers=4`.
- Update `mypy-docs` `doccmd` invocation to pass the same workers setting inside `--command`.

## Test plan
- [x] Run repository pre-commit hooks during commit.
- [x] Verify `.pre-commit-config.yaml` includes worker flag for both `mypy` and `mypy-docs` entries.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes pre-push developer tooling by adding `--num-workers=4` to `mypy` invocations, affecting performance/timing but not runtime behavior.
> 
> **Overview**
> Speeds up the `mypy` pre-push hooks by enabling parallel type-checking with `--num-workers=4`.
> 
> Updates both the direct `mypy` hook and the `mypy-docs` `doccmd` invocation so documentation-embedded type checks run with the same worker setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a05f99fba565e9215121333e625adfbeda6c124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->