### PR TITLE
Add strict-kwargs pre-commit hook in fix mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -303,7 +303,6 @@ repos:
         additional_dependencies:
           - *uv_version
 
-
       - id: strict-kwargs-fix
         name: strict-kwargs
         entry: uv run --extra=dev strict-kwargs fix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ ci:
     - shfmt
     - shfmt-docs
     - sphinx-lint
+    - strict-kwargs-fix
     - vulture
     - vulture-docs
     - yamlfix
@@ -301,6 +302,16 @@ repos:
         types_or: [markdown, rst]
         additional_dependencies:
           - *uv_version
+
+
+      - id: strict-kwargs-fix
+        name: strict-kwargs
+        entry: uv run --extra=dev strict-kwargs fix
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        require_serial: true
 
       - id: doc8
         name: doc8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,7 @@ dependencies = [
     "docutils>=0.19",
     "sphinx>=8.2.3",
 ]
-optional-dependencies.dev = [
-    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
     "beartype==0.22.9",
     "check-manifest==0.51",
     "deptry==0.25.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ optional-dependencies.dev = [
     "shellcheck-py==0.11.0.1",
     "shfmt-py==4.0.0",
     "sphinx-lint==1.0.2",
-    "strict-kwargs==2026.5.18",
+    "strict-kwargs==2026.5.18.post1",
     "ty==0.0.36",
     "types-docutils==0.22.3.20260508",
     "vulture==2.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.25.1",
+
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Source = "https://github.com/adamtheturtle/sphinx-combine"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dependencies = [
     "docutils>=0.19",
     "sphinx>=8.2.3",
 ]
-optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [
+    "actionlint-py==1.7.12.24",
     "beartype==0.22.9",
     "check-manifest==0.51",
     "deptry==0.25.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ optional-dependencies.dev = [
     "shellcheck-py==0.11.0.1",
     "shfmt-py==4.0.0",
     "sphinx-lint==1.0.2",
+    "strict-kwargs==2026.5.18",
     "ty==0.0.36",
     "types-docutils==0.22.3.20260508",
     "vulture==2.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.25.1",
-
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Source = "https://github.com/adamtheturtle/sphinx-combine"


### PR DESCRIPTION
## Summary
- Add the [strict-kwargs](https://github.com/adamtheturtle/strict-kwargs) pre-commit hook (`rev: 2026.5.18`) with `args: [fix]` so positional call arguments are rewritten to keyword form on commit.
- Skip the hook in pre-commit CI (builds from source and needs a Rust toolchain).
- Mirror `[tool.mypy_strict_kwargs]` into `[tool.strict_kwargs]` where custom ignore lists already exist.

## Test plan
- [ ] `pre-commit run strict-kwargs --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates developer tooling by adding a new formatter-style pre-commit hook and its dev dependency, with no runtime code changes.
> 
> **Overview**
> Adds a new local pre-commit hook, `strict-kwargs-fix`, which runs `strict-kwargs fix` (serially) to rewrite positional call arguments into keyword form.
> 
> Updates tooling config to *skip this hook in pre-commit CI* and adds `strict-kwargs` to the `dev` optional dependencies in `pyproject.toml` so it can run locally via `uv`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d00e8a97e38cfd9adc7ace7bd051e7ed1c8e2ebb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->