### PR TITLE
Ban dynamic builtins and typing.cast in lint config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ lint.per-file-ignores."doccmd_*.py" = [
 lint.unfixable = [
     "ERA001",
 ]
+lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
 
 [tool.pylint]
@@ -171,6 +172,17 @@ MASTER.load-plugins = [
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 MASTER.unsafe-load-any-extension = false
+DEPRECATED_BUILTINS.bad-functions = [
+    # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
+    # make this removable:
+    # https://github.com/astral-sh/ruff/issues/10079
+    # https://github.com/astral-sh/ruff/issues/970
+    "filter",
+    "getattr",
+    "hasattr",
+    "map",
+    "setattr",
+]
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where


### PR DESCRIPTION
## Summary
- Add literalizer DEPRECATED_BUILTINS.bad-functions pylint config (filter, getattr, hasattr, map, setattr).
- Ban typing.cast imports via ruff flake8-tidy-imports where the project uses ruff.
- Fix or pylint-disable existing violations uncovered by the new rules.

## Test plan
- [ ] CI lint passes (pylint, ruff, pre-commit).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only tightens lint configuration, but it may cause new lint failures in downstream/unused code paths if those APIs are still used.
> 
> **Overview**
> Tightens lint rules by **banning `typing.cast` imports via Ruff (`flake8-tidy-imports`)** and by configuring Pylint to flag use of selected *dynamic builtins* (`filter`, `map`, `getattr`, `setattr`, `hasattr`) via `DEPRECATED_BUILTINS.bad-functions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 472b813c1f986577df9a76e39fefffc017d30bd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->