### PR TITLE
Run shfmt through uv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,7 +112,7 @@ repos:
 
       - id: shfmt
         name: shfmt
-        entry: shfmt --write --space-redirects --indent=4
+        entry: uv run --extra=dev shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
         additional_dependencies:


### PR DESCRIPTION
## What changed

- Run the `shfmt` pre-commit hook through `uv run --extra=dev`.

## Why

The project already pins `shfmt-py` in its development dependencies. Invoking `shfmt` directly made this hook inconsistent with the other project-tool hooks and allowed an ambient executable to be used instead of the pinned development environment.

## Impact

The hook now uses the project-pinned `shfmt` version. Formatting behavior and arguments are unchanged.

## Validation

- `uv run --extra=dev shfmt --version`
- `uv run --extra=dev prek run shfmt --all-files`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single pre-commit config line; no application or runtime code changes, only which shfmt binary the hook uses.
> 
> **Overview**
> The **`shfmt`** pre-commit hook now invokes **`uv run --extra=dev shfmt`** instead of a bare **`shfmt`** on **`PATH`**, matching hooks like **`shellcheck`** and **`actionlint`**.
> 
> **`shfmt`** flags (**`--write --space-redirects --indent=4`**) are unchanged; only the executable resolution uses the project-pinned **`shfmt-py`** dev dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6329a036ebd1c46b38ba05e4f0ffe16d0440d51a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->