### PR TITLE
Lint Markdown prose with Vale

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -284,7 +284,7 @@ repos:
         require_serial: true
 
       # Vale enforces prose style rules, such as banning em dashes, in
-      # reStructuredText files.
+      # reStructuredText and Markdown files.
       # The rules come from the ``ClearProse`` package pinned in ``.vale.ini``,
       # which ``vale sync`` downloads into the (gitignored) ``styles``
       # directory.
@@ -298,7 +298,7 @@ repos:
         entry: uv run --extra=dev vale sync
         language: python
         pass_filenames: false
-        files: (\.rst$|^\.vale\.ini$)
+        files: (\.(rst|md)$|^\.vale\.ini$)
         additional_dependencies:
           - *uv_version
 
@@ -306,7 +306,7 @@ repos:
         name: vale
         entry: uv run --extra=dev vale
         language: python
-        types_or: [rst]
+        types_or: [rst, markdown]
         require_serial: true
         additional_dependencies:
           - *uv_version

--- a/.vale.ini
+++ b/.vale.ini
@@ -3,5 +3,5 @@ MinAlertLevel = error
 
 Packages = https://github.com/adamtheturtle/vale-style-clear-prose/releases/download/v1.1.0/ClearProse.zip
 
-[*.rst]
+[*.{rst,md}]
 BasedOnStyles = ClearProse


### PR DESCRIPTION
Follow-up to the change that banned em dashes in reStructuredText.

`.rst` was the wrong boundary: it came from the shape of the original vws-python change, not from where our prose lives. Markdown is prose too, and nothing was checking it. Vale now lints both (`[*.{rst,md}]`), and the `vale` hook gains `markdown` to its `types_or` while `vale sync` re-runs for `.md` changes as well.

No prose changes were needed here; the existing Markdown is already clean. The value is preventive, and it makes the rule consistent across every repository that has this hook.

Verified locally: Vale reports no alerts over the tracked `.rst` and `.md` files, and `prek run` over the changed files passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only change to pre-commit and Vale config; no runtime or security impact, only stricter checks on edited `.md` files.
> 
> **Overview**
> **Vale ClearProse** now applies to **Markdown** as well as reStructuredText, so the same prose rules (for example no em dashes) cover both formats instead of only `.rst`.
> 
> In **`.vale.ini`**, the scope moves from `[*.rst]` to `[*.{rst,md}]`. In **`.pre-commit-config.yaml`**, the `vale` hook adds `markdown` to `types_or`, `vale-sync`’s `files` pattern includes `.md`, and the hook comment notes Markdown is included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f9910baa5796a40cfbb8f038fdbf0be72c54cf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->