### PR TITLE
Bump beartype to 0.23.0rc0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",
-    "beartype==0.22.9",
+    "beartype==0.23.0rc0",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",


### PR DESCRIPTION
Tests the [beartype 0.23.0rc0](https://pypi.org/project/beartype/0.23.0rc0/) release candidate against this repository's test suite.

Pins `beartype` to the release candidate in `pyproject.toml` and updates `uv.lock` to match.

Not intended to merge as-is — the pin should be relaxed once the release candidate has been evaluated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only dependency pin with no runtime or production impact; intended as short-lived RC testing.
> 
> **Overview**
> Pins the **dev** dependency `beartype` from `0.22.9` to **`0.23.0rc0`** so CI and local test runs exercise the upcoming beartype release candidate alongside `pytest-beartype-tests`.
> 
> This is a temporary evaluation change: the pin is meant to be relaxed after the RC is validated, not merged as a permanent RC pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 539231377ca89b208149f14b28ef5229f87676c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->